### PR TITLE
Backends selection support + PID1 process reaper + Alpine semver handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19.0
+FROM alpine:3.19
 
 RUN apk add --update --no-cache bash sane-saned sane-utils sane-backends busybox-extras && \
     echo "6566 stream tcp nowait root.root /usr/sbin/saned saned" >/etc/inetd.conf && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.19.0
 
-RUN apk add --update --no-cache bash sane-saned sane-utils sane-backend-epson sane-backend-epson2 busybox-extras && \
+RUN apk add --update --no-cache bash sane-saned sane-utils sane-backends busybox-extras && \
     echo "6566 stream tcp nowait root.root /usr/sbin/saned saned" >/etc/inetd.conf && \
     addgroup saned lp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.19
 
-RUN apk add --update --no-cache bash sane-saned sane-utils sane-backends busybox-extras && \
+RUN apk add --update --no-cache bash catatonit sane-saned sane-utils sane-backends busybox-extras && \
     echo "6566 stream tcp nowait root.root /usr/sbin/saned saned" >/etc/inetd.conf && \
     addgroup saned lp && \
     rm -rf /etc/sane.d/dll.d/* /etc/sane.d/dll.conf
@@ -10,4 +10,5 @@ ADD entrypoint.sh /entrypoint.sh
 EXPOSE 6566-6570
 ENV DATA_PORT_RANGE="6567-6570" ALLOW_HOSTS="192.168.1.0/24" BACKENDS=""
 
-ENTRYPOINT [ "/entrypoint.sh" ]
+ENTRYPOINT [ "/usr/bin/catatonit", "--" ]
+CMD [ "/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,12 @@ FROM alpine:3.19.0
 
 RUN apk add --update --no-cache bash sane-saned sane-utils sane-backends busybox-extras && \
     echo "6566 stream tcp nowait root.root /usr/sbin/saned saned" >/etc/inetd.conf && \
-    addgroup saned lp
+    addgroup saned lp && \
+    rm -rf /etc/sane.d/dll.d/* /etc/sane.d/dll.conf
 
 ADD entrypoint.sh /entrypoint.sh
 
 EXPOSE 6566-6570
-ENV DATA_PORT_RANGE="6567-6570" ALLOW_HOSTS="192.168.1.0/24"
+ENV DATA_PORT_RANGE="6567-6570" ALLOW_HOSTS="192.168.1.0/24" BACKENDS=""
 
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@
 |-------------------|--------------------|---------------------------|
 | `DATA_PORT_RANGE` | `"6567-6570"`      | The port range to use for the data connection. |
 | `ALLOW_HOSTS`     | `"192.168.1.0/24"` | A space-separated list of IP addresses or ranges allowed to use the `saned` server.|
+| `BACKENDS`        | `""` | A space-separated list of backends to be used within `saned` server.|

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,4 +16,4 @@ for BACKEND in ${BACKENDS}; do
 done
 
 echo "Launching saned"
-/usr/sbin/saned -l -e
+exec /usr/sbin/saned -l -e

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,5 +10,10 @@ for HOST in ${ALLOW_HOSTS}; do
   echo $HOST >> /etc/sane.d/saned.conf
 done
 
+for BACKEND in ${BACKENDS}; do
+  echo "Adding $BACKEND to allowed hosts"
+  echo $BACKEND >> /etc/sane.d/dll.conf
+done
+
 echo "Launching saned"
 inetd -f -e

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,9 +11,9 @@ for HOST in ${ALLOW_HOSTS}; do
 done
 
 for BACKEND in ${BACKENDS}; do
-  echo "Adding $BACKEND to allowed hosts"
+  echo "Adding $BACKEND to allowed backend"
   echo $BACKEND >> /etc/sane.d/dll.conf
 done
 
 echo "Launching saned"
-inetd -f -e
+/usr/sbin/saned -l -e


### PR DESCRIPTION
Hello!

I want to merge following features

* Backends selection support: By using [sane-backends](https://pkgs.alpinelinux.org/packages?name=sane-backends&branch=edge&repo=&arch=&maintainer=) package and handling dll.d and dll.conf it's possible to pick at runtime backends user want to saned to want come up
* PID1 process reaper: Adding [catatonit](https://github.com/openSUSE/catatonit) to container allow signal to be properly handled by saned when signal was sent by docker (docker rm as example).
* saned without inetd: inetd was not necessary since saned can listen directly leading to a lighter resource usage
* Alpine version handling: Since Alpine Linux adopt [semantic versioning](https://wiki.alpinelinux.org/wiki/Package_policies), it's trusteable that same major and minor version will keep compatibility and release version will bring fixes that does not break compatibility. This is important to allow image to has latest security fixes without compromise stability. 

Also, I've enabled actions in my repo, so you can try it at ghcr.io/leleobhz/sane:latest

Can this PR be merged? 

Thanks!